### PR TITLE
Update URL generated for PR review

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -290,12 +290,15 @@ async function run() {
     const githubToken = core.getInput("GITHUB_TOKEN", { required: true });
     const pullRequestTitle = core.getInput("PULL_REQUEST_TITLE");
     const pullRequestBody = core.getInput("PULL_REQUEST_BODY");
+    const pullRequestAutoMergeMethod = core.getInput("PULL_REQUEST_AUTO_MERGE_METHOD");
     const pullRequestIsDraft =
       core.getInput("PULL_REQUEST_IS_DRAFT").toLowerCase() === "true";
     const contentComparison =
       core.getInput("CONTENT_COMPARISON").toLowerCase() === "true";
     const reviewers = JSON.parse(core.getInput("REVIEWERS"));
     const team_reviewers = JSON.parse(core.getInput("TEAM_REVIEWERS"));
+    const labels = JSON.parse(core.getInput("LABELS"));
+    let isMerged = false;
 
     console.log(
       `Should a pull request to ${toBranch} from ${fromBranch} be created?`
@@ -347,11 +350,34 @@ async function run() {
           });
         }
 
+        if (labels.length > 0) {
+          octokit.rest.issues.addLabels({
+            owner,
+            repo,
+            issue_number: pullRequest.number,
+            labels
+          })
+        }
+
+        if (pullRequestAutoMergeMethod) {
+          try {
+            await octokit.rest.pulls.merge({
+              owner,
+              repo,
+              pull_number: pullRequest.number,
+              merge_method: pullRequestAutoMergeMethod
+            });
+            isMerged = true;
+          } catch (err) {
+            isMerged = false;
+          }
+        }
+
         console.log(
-          `Pull request (${pullRequest.number}) successful! You can view it here: ${pullRequest.url}`
+          `Pull request (${pullRequest.number}) successfully created${isMerged ? ' and merged' : ' '}! You can view it here: ${pullRequest.url}`
         );
 
-        core.setOutput("PULL_REQUEST_URL", pullRequest.url.toString());
+        core.setOutput("PULL_REQUEST_URL", pullRequest.html_url.toString());
         core.setOutput("PULL_REQUEST_NUMBER", pullRequest.number.toString());
       } else {
         console.log(
@@ -361,10 +387,10 @@ async function run() {
     } else {
       console.log(
         `There is already a pull request (${currentPull.number}) to ${toBranch} from ${fromBranch}.`,
-        `You can view it here: ${currentPull.url}`
+        `You can view it here: ${currentPull.html_url}`
       );
 
-      core.setOutput("PULL_REQUEST_URL", currentPull.url.toString());
+      core.setOutput("PULL_REQUEST_URL", currentPull.html_url.toString());
       core.setOutput("PULL_REQUEST_NUMBER", currentPull.number.toString());
     }
   } catch (error) {

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ async function run() {
           `Pull request (${pullRequest.number}) successfully created${isMerged ? ' and merged' : ' '}! You can view it here: ${pullRequest.url}`
         );
 
-        core.setOutput("PULL_REQUEST_URL", pullRequest.url.toString());
+        core.setOutput("PULL_REQUEST_URL", pullRequest.html_url.toString());
         core.setOutput("PULL_REQUEST_NUMBER", pullRequest.number.toString());
       } else {
         console.log(
@@ -107,10 +107,10 @@ async function run() {
     } else {
       console.log(
         `There is already a pull request (${currentPull.number}) to ${toBranch} from ${fromBranch}.`,
-        `You can view it here: ${currentPull.url}`
+        `You can view it here: ${currentPull.html_url}`
       );
 
-      core.setOutput("PULL_REQUEST_URL", currentPull.url.toString());
+      core.setOutput("PULL_REQUEST_URL", currentPull.html_url.toString());
       core.setOutput("PULL_REQUEST_NUMBER", currentPull.number.toString());
     }
   } catch (error) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "sync-branches",
       "version": "1.4.0",
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Changes

- The URL for PR created reference in action logs is API url 
![image](https://github.com/user-attachments/assets/9f4f12d9-522a-40e4-ba52-59d82698e3b5)

- So this doesn't send us to required endpoint 
- Updated the use of `url` to `html_url` instead
![image](https://github.com/user-attachments/assets/a8dba3fd-1573-41ac-8e55-fbc2c40a9d2a)


## Resolves => https://github.com/TreTuna/sync-branches/issues/85