### PR TITLE
Gracefully handle the collaborator missing error

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -290,12 +290,15 @@ async function run() {
     const githubToken = core.getInput("GITHUB_TOKEN", { required: true });
     const pullRequestTitle = core.getInput("PULL_REQUEST_TITLE");
     const pullRequestBody = core.getInput("PULL_REQUEST_BODY");
+    const pullRequestAutoMergeMethod = core.getInput("PULL_REQUEST_AUTO_MERGE_METHOD");
     const pullRequestIsDraft =
       core.getInput("PULL_REQUEST_IS_DRAFT").toLowerCase() === "true";
     const contentComparison =
       core.getInput("CONTENT_COMPARISON").toLowerCase() === "true";
     const reviewers = JSON.parse(core.getInput("REVIEWERS"));
     const team_reviewers = JSON.parse(core.getInput("TEAM_REVIEWERS"));
+    const labels = JSON.parse(core.getInput("LABELS"));
+    let isMerged = false;
 
     console.log(
       `Should a pull request to ${toBranch} from ${fromBranch} be created?`
@@ -338,17 +341,45 @@ async function run() {
         });
 
         if (reviewers.length > 0 || team_reviewers.length > 0) {
-          octokit.rest.pulls.requestReviewers({
+          try {
+            await octokit.rest.pulls.requestReviewers({
+              owner,
+              repo,
+              pull_number: pullRequest.number,
+              reviewers,
+              team_reviewers,
+            });
+          } catch (error) {
+            core.error(`Reviews may only be requested from collaborators. One or more of the users or teams you specified is not a collaborator of the ${repo} repository.`)
+            core.error('No reviewers will be requested. Please update the reviewier list to include only collaborators or remove non-collaborators from team.')
+          }
+        }
+
+        if (labels.length > 0) {
+          octokit.rest.issues.addLabels({
             owner,
             repo,
-            pull_number: pullRequest.number,
-            reviewers,
-            team_reviewers,
-          });
+            issue_number: pullRequest.number,
+            labels
+          })
+        }
+
+        if (pullRequestAutoMergeMethod) {
+          try {
+            await octokit.rest.pulls.merge({
+              owner,
+              repo,
+              pull_number: pullRequest.number,
+              merge_method: pullRequestAutoMergeMethod
+            });
+            isMerged = true;
+          } catch (err) {
+            isMerged = false;
+          }
         }
 
         console.log(
-          `Pull request (${pullRequest.number}) successful! You can view it here: ${pullRequest.url}`
+          `Pull request (${pullRequest.number}) successfully created${isMerged ? ' and merged' : ' '}! You can view it here: ${pullRequest.url}`
         );
 
         core.setOutput("PULL_REQUEST_URL", pullRequest.url.toString());

--- a/index.js
+++ b/index.js
@@ -61,13 +61,18 @@ async function run() {
         });
 
         if (reviewers.length > 0 || team_reviewers.length > 0) {
-          octokit.rest.pulls.requestReviewers({
-            owner,
-            repo,
-            pull_number: pullRequest.number,
-            reviewers,
-            team_reviewers,
-          });
+          try {
+            await octokit.rest.pulls.requestReviewers({
+              owner,
+              repo,
+              pull_number: pullRequest.number,
+              reviewers,
+              team_reviewers,
+            });
+          } catch (error) {
+            core.error(`Reviews may only be requested from collaborators. One or more of the users or teams you specified is not a collaborator of the ${repo} repository.`)
+            core.error('No reviewers will be requested. Please update the reviewier list to include only collaborators or remove non-collaborators from team.')
+          }
         }
 
         if (labels.length > 0) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "sync-branches",
       "version": "1.4.0",
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Changes

- Wrap the collaborator review request API call with try catch
- Just log the error instead of failing the action status
- It creates the PR despite before but the action run status is set to error which is a bit annoying. So, error info is shown instead which gives info about the handling 

## Test
- Messages shown when error

### Before
https://github.com/samirsilwal/sync-branches/actions/runs/11310223756/job/31455026490

## After
![image](https://github.com/user-attachments/assets/b428da84-9816-43e8-a9fc-c6126bc20be2)
